### PR TITLE
chore(platform): add Delicias application contract

### DIFF
--- a/.platform/app.yaml
+++ b/.platform/app.yaml
@@ -1,0 +1,55 @@
+apiVersion: platform.delicias/v1alpha2
+kind: Application
+metadata:
+  name: bigmac-index
+spec:
+  owner: group:platform
+  repository: https://github.com/danielbeltejar/bigmac-index
+  defaultBranch: main
+  components:
+    - name: front
+      build:
+        context: front
+        dockerfile: front/Dockerfile
+      deploy:
+        kind: service
+        containerPort: 8080
+        servicePort: 80
+        healthPath: /healthz
+    - name: back
+      build:
+        context: back
+        dockerfile: back/Dockerfile
+      deploy:
+        kind: service
+        containerPort: 8000
+        servicePort: 80
+        healthPath: /healthz
+    - name: scraper
+      build:
+        context: scraper
+        dockerfile: scraper/Dockerfile
+      deploy:
+        kind: worker
+  runtime:
+    - name: apigw
+      image: harbor.server.local/danielbeltejar/common/apigw
+      digest: sha256:1e8a77888a0110b8b30b794a2414d0eb2bc4c23aae38ecec14ca74c66299b494
+      deploy:
+        kind: service
+        containerPort: 8080
+        servicePort: 80
+        healthPort: 8081
+        healthPath: /healthz
+  environments:
+    pre:
+      automatic: true
+    pro:
+      automatic: false
+  promotion:
+    strategy: pull-request
+    from: pre
+    to: pro
+  artifacts:
+    registry: harbor.server.local/danielbeltejar/bigmac-index
+    imageReference: digest

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,108 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: bigmac-index
+  description: BigMac index application
+  annotations:
+    github.com/project-slug: danielbeltejar/bigmac-index
+    backstage.io/source-location: url:https://github.com/danielbeltejar/bigmac-index
+    delicias.dev/managed-by: backstage
+    delicias.dev/workload-kind: application
+    delicias.dev/application-contract: platform.delicias/v1alpha2
+    delicias.dev/delivery-chart: common-app@1.1.0
+    delicias.dev/runtime-components: apigw
+spec:
+  lifecycle: production
+  owner: group:platform
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bigmac-index-front
+  description: BigMac index frontend
+  annotations:
+    github.com/project-slug: danielbeltejar/bigmac-index
+    backstage.io/source-location: url:https://github.com/danielbeltejar/bigmac-index
+    tekton.dev/pipeline: universal-monorepo
+    backstage.io/kubernetes-id: front
+    backstage.io/kubernetes-namespace: pre-bigmac-index-front
+    delicias.dev/managed-by: backstage
+    delicias.dev/workload-kind: application
+    delicias.dev/application-contract: platform.delicias/v1alpha2
+    delicias.dev/deploy-kind: service
+    delicias.dev/delivery-chart: common-app@1.1.0
+  tags: [gitops, kubernetes, monorepo, common-app]
+spec:
+  type: website
+  lifecycle: production
+  owner: group:platform
+  system: bigmac-index
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bigmac-index-back
+  description: BigMac index API
+  annotations:
+    github.com/project-slug: danielbeltejar/bigmac-index
+    backstage.io/source-location: url:https://github.com/danielbeltejar/bigmac-index
+    tekton.dev/pipeline: universal-monorepo
+    backstage.io/kubernetes-id: back
+    backstage.io/kubernetes-namespace: pre-bigmac-index-back
+    delicias.dev/managed-by: backstage
+    delicias.dev/workload-kind: application
+    delicias.dev/application-contract: platform.delicias/v1alpha2
+    delicias.dev/deploy-kind: service
+    delicias.dev/delivery-chart: common-app@1.1.0
+  tags: [gitops, kubernetes, monorepo, common-app]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:platform
+  system: bigmac-index
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bigmac-index-scraper
+  description: BigMac index refresh worker
+  annotations:
+    github.com/project-slug: danielbeltejar/bigmac-index
+    backstage.io/source-location: url:https://github.com/danielbeltejar/bigmac-index
+    tekton.dev/pipeline: universal-monorepo
+    backstage.io/kubernetes-id: scraper
+    backstage.io/kubernetes-namespace: pre-bigmac-index-back
+    delicias.dev/managed-by: backstage
+    delicias.dev/workload-kind: application
+    delicias.dev/application-contract: platform.delicias/v1alpha2
+    delicias.dev/deploy-kind: worker
+    delicias.dev/delivery-chart: common-app@1.1.0
+  tags: [gitops, kubernetes, monorepo, common-app, worker]
+spec:
+  type: worker
+  lifecycle: production
+  owner: group:platform
+  system: bigmac-index
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: bigmac-index-apigw
+  description: BigMac index API gateway
+  annotations:
+    github.com/project-slug: danielbeltejar/bigmac-index
+    backstage.io/source-location: url:https://github.com/danielbeltejar/bigmac-index
+    backstage.io/kubernetes-id: apigw
+    backstage.io/kubernetes-namespace: pre-bigmac-index-front
+    delicias.dev/managed-by: backstage
+    delicias.dev/workload-kind: application
+    delicias.dev/application-contract: platform.delicias/v1alpha2
+    delicias.dev/deploy-kind: service
+    delicias.dev/delivery-chart: common-app@1.1.0
+    delicias.dev/runtime-component: apigw
+  tags: [gitops, kubernetes, common-app, runtime]
+spec:
+  type: service
+  lifecycle: production
+  owner: group:platform
+  system: bigmac-index


### PR DESCRIPTION
Adds the standard platform.delicias/v1alpha2 contract and Backstage catalog entities for the existing monorepo. No runtime manifests, images, or application code are changed.