### PR TITLE
fix(ci): remove explicit root dockerfile directives

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.11-alpine
 
-USER root
-
 # Create a non-root user to run the application
 RUN adduser -D appuser
 
@@ -39,4 +37,3 @@ USER appuser
 
 # Run the application with uvicorn
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.11-alpine
 
-USER root
-
 # Create a non-root user to run the application
 RUN adduser -D appuser
 
@@ -36,4 +34,3 @@ USER appuser
 
 # Run the application with uvicorn
 CMD ["python", "main.py"]
-


### PR DESCRIPTION
The universal Tekton security lint rejects explicit `USER root` directives.

The build steps still run as the default root user where package installation needs it, while both runtime images already switch to their dedicated non-root `appuser`.